### PR TITLE
Fix boundary writing issue (#420)

### DIFF
--- a/Code/Source/solver/txt.cpp
+++ b/Code/Source/solver/txt.cpp
@@ -497,11 +497,10 @@ void write_boundary_integral_data(const ComMod& com_mod, CmMod& cm_mod, const eq
         fprintf(fp, " %.10e ", tmp);
       }
     }
-
-    if (com_mod.cm.mas(cm_mod)) {
-      fprintf(fp, "\n");
-      fclose(fp);
-    }
+  }
+  if (com_mod.cm.mas(cm_mod)) {
+    fprintf(fp, "\n");
+    fclose(fp);
   }
 }
 


### PR DESCRIPTION
For simulation with multiple meshes, the output txt file should be closed after it loops over all meshes.